### PR TITLE
Cat commands, docker optimzation and move all persistent data under the same docker volume

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         uses: coverallsapp/github-action@v2
         with:
           parallel: true
-          flag-name: run-${{ join(matrix.*, ' - ') }}
+          flag-name: py ${{ matrix.python-version }} - uv ${{ matrix.uv-version }}
 
   finish:
     needs: lint-build-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,18 @@ jobs:
 
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@v2
+        with:
+          parallel: true
+          flag-name: run-${{ join(matrix.*, ' - ') }}
+
+  finish:
+    needs: lint-build-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Finish Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          parallel-finished: true
 
   docker:
     name: Docker Build & Push

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Data files
+persistent/
 sounds/
 audio_cache/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,10 +62,6 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Audio cache directories
-ENV AUDIO_CACHE_DIR="/app/audio_cache"
-VOLUME ["/app/audio_cache"]
-
 # Mount persistent data directories
 ENV PERSISTENT_DATA_DIR="/app/persistent"
 VOLUME ["/app/persistent"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,11 @@ RUN apt-get update \
 ENV AUDIO_CACHE_DIR="/app/audio_cache"
 VOLUME ["/app/audio_cache"]
 
-# # Copy sound effects from the builder
+# Mount persistent data directories
+ENV PERSISTENT_DATA_DIR="/app/persistent"
+VOLUME ["/app/persistent"]
+
+# Copy sound effects from the builder
 COPY --from=builder --chown=app:app /app/sounds /app/sounds
 
 # Copy the app and pre-built venv from the builder - that should be all that's needed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,50 +1,80 @@
 ARG DEBIAN_VERSION=bookworm
-ARG UV_VERSION=latest
-ARG VARIANT=3.13
+ARG UV_VERSION=0.7.12
+ARG PY_VERSION=3.13
 
+FROM ghcr.io/astral-sh/uv:python${PY_VERSION}-${DEBIAN_VERSION}-slim AS builder
 
-FROM ghcr.io/astral-sh/uv:$UV_VERSION AS uv
+# Enable bytecode compilation
+ENV UV_COMPILE_BYTECODE=1
 
-
-FROM python:$VARIANT-slim-$DEBIAN_VERSION
-
-WORKDIR /app
-
-COPY --from=uv /uv /uvx /bin/
-COPY pyproject.toml uv.lock ./
-
-ENV PYTHONDONTWRITEBYTECODE=True
-ENV PYTHONUNBUFFERED=True
+# Copy from the cache instead of linking since it's a mounted volume
 ENV UV_LINK_MODE=copy
 
-# hadolint ignore=DL3008
+# Disable Python downloads, because we want to use the system interpreter
+# across both images. If using a managed Python version, it needs to be
+# copied from the build image into the final image; see `standalone.Dockerfile`
+# for an example.
+ENV UV_PYTHON_DOWNLOADS=0
+
+# Install packages needed for building the app
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-    build-essential=12.9 \
-    ca-certificates=20230311 \
-    curl=7.88.1-10+deb12u12 \
-    ffmpeg=7:5.1.6-0+deb12u1 \
-    libopus0=1.3.1-3 \
-    make=4.3-4.1 \
+    # build-essential=12.9 \
+    # ca-certificates=20230311 \
+    # curl=7.88.1-10+deb12u12 \
+    # make=4.3-4.1 \
     unzip=6.0-28 \
     # To remove the image size, it is recommended refresh the package cache as follows
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# bring in the zip so we can unpack at runtime
-COPY sounds.zip /app/sounds.zip
-COPY Makefile /app/Makefile
-RUN make unpack
+# Build the project in `/app`
+WORKDIR /app
 
+# Add in sound effect files and unpack them
+COPY sounds.zip .
+RUN unzip -u sounds.zip
+
+# Install the project's dependencies using the lockfile and settings
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync --locked --no-install-project --no-dev
+
+# Then, add the rest of the project source code and install it
+# Installing separately from its dependencies allows optimal layer caching
 COPY . /app
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked --no-dev
 
-# Cache directories
+# Then, use a final image without uv - make sure the versions match the builder!
+FROM python:${PY_VERSION}-slim-${DEBIAN_VERSION}
+
+# Run from the app dir
+WORKDIR /app
+
+# Install packages needed for running the app
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    ffmpeg=7:5.1.6-0+deb12u1 \
+    libopus0=1.3.1-3 \
+    # To remove the image size, it is recommended refresh the package cache as follows
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Audio cache directories
 ENV AUDIO_CACHE_DIR="/app/audio_cache"
-
 VOLUME ["/app/audio_cache"]
 
-# entrypoint script
-RUN chmod +x ./start.sh
+# # Copy sound effects from the builder
+COPY --from=builder --chown=app:app /app/sounds /app/sounds
 
-# default command
-ENTRYPOINT ["./start.sh"]
+# Copy the app and pre-built venv from the builder - that should be all that's needed
+COPY --from=builder --chown=app:app /app/src /app/src
+COPY --from=builder --chown=app:app /app/.venv /app/.venv
+
+# Place executables in the environment at the front of the path
+ENV PATH="/app/.venv/bin:$PATH"
+
+# Run the built app
+CMD ["balaambot"]

--- a/Makefile
+++ b/Makefile
@@ -29,22 +29,16 @@ clean:
 	rm -rf build/ dist/ *.egg-info
 	# Remove sounds directory if it exists
 	rm -rf sounds/
-	rm -rf audio_cache/
+	rm -rf persistent/
 	rm .coverage
 
 docker-build:
 	docker build -t balaambot:latest .
 
-HOST_CACHED_DIR=$(PWD)/audio_cache
-PERSISTENT_DIR=$(PWD)/persistent
-
 docker-run:
-	@mkdir -p $(HOST_CACHED_DIR)
-	@mkdir -p $(PERSISTENT_DIR)
 	docker run --rm -it \
 		--env-file .env \
-		-v $(HOST_CACHED_DIR):/app/audio_cache \
-		-v $(PERSISTENT_DIR):/app/persistent \
+		-v $(PWD)/persistent:/app/persistent \
 		balaambot:latest
 
 docker-brun: docker-build docker-run

--- a/Makefile
+++ b/Makefile
@@ -36,12 +36,15 @@ docker-build:
 	docker build -t balaambot:latest .
 
 HOST_CACHED_DIR=$(PWD)/audio_cache
+PERSISTENT_DIR=$(PWD)/persistent
 
 docker-run:
 	@mkdir -p $(HOST_CACHED_DIR)
+	@mkdir -p $(PERSISTENT_DIR)
 	docker run --rm -it \
 		--env-file .env \
 		-v $(HOST_CACHED_DIR):/app/audio_cache \
+		-v $(PERSISTENT_DIR):/app/persistent \
 		balaambot:latest
 
 docker-brun: docker-build docker-run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "yt-dlp>=2025.5.22",
     "pytest-cov>=6.1.1",
     "pyjokes>=0.8.3",
+    "pydantic>=2.11.5",
 ]
 
 # Dev tools

--- a/src/balaambot/audio_handlers/youtube_audio.py
+++ b/src/balaambot/audio_handlers/youtube_audio.py
@@ -1,7 +1,6 @@
 import asyncio
 import atexit
 import logging
-import os
 import re
 import shutil
 import time
@@ -11,12 +10,14 @@ from typing import Any, TypedDict, cast
 
 from yt_dlp import DownloadError, YoutubeDL  # type: ignore[import]
 
+import balaambot.config
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_SAMPLE_RATE = 48000  # Default sample rate for PCM audio
 DEFAULT_CHANNELS = 2  # Default number of audio channels (stereo)
 
-AUDIO_CACHE_ROOT = os.getenv("AUDIO_CACHE_DIR", "./audio_cache")
+AUDIO_CACHE_ROOT = Path(balaambot.config.PERSISTENT_DATA_DIR) / "audio_cache"
 
 logger.info(
     "Using a sample rate of %dHz with %d channels",
@@ -26,11 +27,11 @@ logger.info(
 logger.info("Using audio download and caching directory: '%s'", AUDIO_CACHE_ROOT)
 
 # Directory for caching PCM audio files
-audio_cache_dir = Path(AUDIO_CACHE_ROOT + "/cached").resolve()
+audio_cache_dir = (AUDIO_CACHE_ROOT / "cached").resolve()
 audio_cache_dir.mkdir(parents=True, exist_ok=True)
 
 # Temporary directory for in-progress downloads
-audio_tmp_dir = Path(AUDIO_CACHE_ROOT + "/downloading").resolve()
+audio_tmp_dir = (AUDIO_CACHE_ROOT / "downloading").resolve()
 audio_tmp_dir.mkdir(parents=True, exist_ok=True)
 
 

--- a/src/balaambot/bot_commands/cat_commands.py
+++ b/src/balaambot/bot_commands/cat_commands.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import pathlib
 import random
 
 import discord
@@ -11,7 +12,7 @@ import balaambot.config
 
 logger = logging.getLogger(__name__)
 
-SAVE_FILE = balaambot.config.PERSISTENT_DATA_DIRECTORY / "cats.json"
+SAVE_FILE = pathlib.Path(balaambot.config.PERSISTENT_DATA_DIR) / "cats.json"
 MSG_NO_CAT = (
     "You don't have any cats yet! :crying_cat_face: Try adopting one with `/adopt`!"
 )

--- a/src/balaambot/bot_commands/cat_commands.py
+++ b/src/balaambot/bot_commands/cat_commands.py
@@ -10,6 +10,12 @@ from discord.ext import commands
 
 import balaambot.config
 
+# TODOs:
+# Use one model for everything to save together
+# Key cats by discord server
+# fuzzy search for cat names (try pkg: the fuzz)
+# move message strings to separate file (cat_commands_strings.py?)
+
 logger = logging.getLogger(__name__)
 
 SAVE_FILE = pathlib.Path(balaambot.config.PERSISTENT_DATA_DIR) / "cats.json"

--- a/src/balaambot/bot_commands/cat_commands.py
+++ b/src/balaambot/bot_commands/cat_commands.py
@@ -1,0 +1,58 @@
+import logging
+import random
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+logger = logging.getLogger(__name__)
+
+
+class CatCommands(commands.Cog):
+    """Slash commands for cat interactions."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        """Initialize the CatCommands cog."""
+        self.bot = bot
+        self.cats = {}
+
+    @app_commands.command(name="adopt", description="Adopt a new cat!")
+    @app_commands.describe(cat="The cat you want to pet")
+    async def adopt_cat(self, interaction: discord.Interaction, cat: str) -> None:
+        """Try to pet a cat with a chance to fail."""
+        logger.info("Received adopt_cat command from: %s", interaction.user)
+        cat_id = cat.strip().lower()
+        if cat_id in self.cats:
+            await interaction.response.send_message(
+                f"You already have a cat named {cat}!",
+            )
+            return
+        self.cats[cat_id] = cat
+        await interaction.response.send_message(
+            f"You adopted a new cat called {cat}! :cat: "
+        )
+
+    @app_commands.command(name="pet", description="Try to pet one of your cats!")
+    @app_commands.describe(cat="The cat you want to pet")
+    async def pet_cat(self, interaction: discord.Interaction, cat: str) -> None:
+        """Try to pet a cat with a chance to fail."""
+        logger.info("Received pet_cat command from: %s", interaction.user)
+        cat_id = cat.strip().lower()
+        if cat_id not in self.cats:
+            await interaction.response.send_message(
+                f"You don't have any cats named {cat}."
+                f"Please choose from: {', '.join(self.cats)}",
+            )
+            return
+        success = random.choices([True, False], [3, 1])  # noqa: S311
+        if success[0]:
+            msg = f"You successfully petted {cat}! They love it! :heart_eyes_cat:"
+        else:
+            msg = f"{cat} ran away before you could pet it!"
+        await interaction.response.send_message(msg)
+
+
+async def setup(bot: commands.Bot) -> None:
+    """Load the CatCommands cog."""
+    logger.info("Loading CatCommands cog")
+    await bot.add_cog(CatCommands(bot))

--- a/src/balaambot/bot_commands/cat_commands.py
+++ b/src/balaambot/bot_commands/cat_commands.py
@@ -112,7 +112,7 @@ class CatCommands(commands.Cog):
         cats_dict = {k: v.model_dump() for k, v in cats.items()}
         with SAVE_FILE.open("w") as f:
             json.dump(cats_dict, f, indent=4)
-        logger.info("Saved cats to %s", SAVE_FILE)
+        logger.info("Saved %d cat(s) to %s", len(cats_dict), SAVE_FILE)
 
     def get_cat_names(self) -> str:
         """Get a formatted list of cat names."""

--- a/src/balaambot/bot_commands/music_commands.py
+++ b/src/balaambot/bot_commands/music_commands.py
@@ -17,6 +17,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# TODOs:
+# check user is in voice channel before searching for tracks
+
 
 class SearchView(View):
     """A view containing buttons for selecting search results."""

--- a/src/balaambot/bot_commands/sfx_commands.py
+++ b/src/balaambot/bot_commands/sfx_commands.py
@@ -12,6 +12,16 @@ from balaambot.schedulers import audio_sfx_jobs
 logger = logging.getLogger(__name__)
 
 
+# TODOs:
+# - too many sounds in the zip
+#   - `/list_sfx`` gives an error because it hits the message size limit
+# - check if sfx file exists before running it and joining channel
+# - sanitize sfx file names and find files with similar names
+# - add fuzzy search
+# - add basic file browser with discord msg buttons
+# - intergrate with soundboard api?
+
+
 class SFXCommands(commands.Cog):
     """Slash commands for scheduling and triggering SFX jobs."""
 

--- a/src/balaambot/config.py
+++ b/src/balaambot/config.py
@@ -1,9 +1,6 @@
 # This file holds all global config variables
 # Import the whole file if you need to access any of these
 import os
-import pathlib
 
 # Docker volume to hold all persistent data
-_persistent_dir_path = os.getenv("PERSISTENT_DATA_DIR", default="persistent")
-PERSISTENT_DATA_DIRECTORY = pathlib.Path(_persistent_dir_path).resolve()
-PERSISTENT_DATA_DIRECTORY.mkdir(parents=True, exist_ok=True)
+PERSISTENT_DATA_DIR = os.getenv("PERSISTENT_DATA_DIR", default="persistent")

--- a/src/balaambot/config.py
+++ b/src/balaambot/config.py
@@ -1,0 +1,5 @@
+# This file holds all global config variables
+# Import the whole file if you need to access any of these
+import pathlib
+
+PERSISTENT_DATA_DIRECTORY = pathlib.Path("persistent")

--- a/src/balaambot/config.py
+++ b/src/balaambot/config.py
@@ -1,5 +1,9 @@
 # This file holds all global config variables
 # Import the whole file if you need to access any of these
+import os
 import pathlib
 
-PERSISTENT_DATA_DIRECTORY = pathlib.Path("persistent")
+# Docker volume to hold all persistent data
+_persistent_dir_path = os.getenv("PERSISTENT_DATA_DIR", default="persistent")
+PERSISTENT_DATA_DIRECTORY = pathlib.Path(_persistent_dir_path).resolve()
+PERSISTENT_DATA_DIRECTORY.mkdir(parents=True, exist_ok=True)

--- a/src/balaambot/main.py
+++ b/src/balaambot/main.py
@@ -7,8 +7,6 @@ import discord
 from discord.ext import commands
 from dotenv import load_dotenv
 
-import balaambot.config
-
 load_dotenv()
 
 logger = logging.getLogger(__name__)
@@ -62,9 +60,6 @@ def start() -> None:
             'Do not wrap the token in "..." inside the .env file!'
         )
         raise ValueError(msg)
-    # Docker volume to hold all persistent data
-    if not balaambot.config.PERSISTENT_DATA_DIRECTORY.exists():
-        balaambot.config.PERSISTENT_DATA_DIRECTORY.mkdir()
     asyncio.run(load_extensions())
     logger.info("Starting bot...")
     bot.run(BOT_TOKEN)

--- a/src/balaambot/main.py
+++ b/src/balaambot/main.py
@@ -7,6 +7,8 @@ import discord
 from discord.ext import commands
 from dotenv import load_dotenv
 
+import balaambot.config
+
 load_dotenv()
 
 logger = logging.getLogger(__name__)
@@ -54,7 +56,9 @@ def start() -> None:
     if BOT_TOKEN is None or BOT_TOKEN == "":
         msg = "DISCORD_BOT_TOKEN environment variable is not set."
         raise ValueError(msg)
-
+    # Docker volume to hold all persistent data
+    if not balaambot.config.PERSISTENT_DATA_DIRECTORY.exists():
+        balaambot.config.PERSISTENT_DATA_DIRECTORY.mkdir()
     asyncio.run(load_extensions())
     logger.info("Starting bot...")
     bot.run(BOT_TOKEN)

--- a/src/balaambot/main.py
+++ b/src/balaambot/main.py
@@ -56,6 +56,12 @@ def start() -> None:
     if BOT_TOKEN is None or BOT_TOKEN == "":
         msg = "DISCORD_BOT_TOKEN environment variable is not set."
         raise ValueError(msg)
+    if '"' in BOT_TOKEN:
+        msg = (
+            "DISCORD_BOT_TOKEN contains invalid characters. "
+            'Do not wrap the token in "..." inside the .env file!'
+        )
+        raise ValueError(msg)
     # Docker volume to hold all persistent data
     if not balaambot.config.PERSISTENT_DATA_DIRECTORY.exists():
         balaambot.config.PERSISTENT_DATA_DIRECTORY.mkdir()

--- a/tests/audio_handlers/test_youtube_audio.py
+++ b/tests/audio_handlers/test_youtube_audio.py
@@ -7,12 +7,13 @@ from pathlib import Path
 
 import pytest
 from yt_dlp.utils import DownloadError
+import balaambot.config
 
 
 # Helper to import the module under test with custom dirs
 def import_module(tmp_cache_root: Path):
-    # Set environment variable before import
-    os.environ["AUDIO_CACHE_DIR"] = str(tmp_cache_root)
+    # Set config variable before import
+    balaambot.config.PERSISTENT_DATA_DIR = str(tmp_cache_root)
 
     # Ensure a fresh import
     module_name = "src.balaambot.audio_handlers.youtube_audio"
@@ -38,10 +39,10 @@ def test_directories_created(tmp_cache_root):
     assert hasattr(mod, "audio_cache_dir")
     assert hasattr(mod, "audio_tmp_dir")
 
-    # In the new code, AUDIO_CACHE_DIR is treated as the root, and subdirectories
+    # In the new code, PERSISTENT_DATA_DIR/audio_cache is treated as the root, and subdirectories
     # 'cached' and 'downloading' are created underneath it
-    expected_cache = (tmp_cache_root / "cached").resolve()
-    expected_tmp = (tmp_cache_root / "downloading").resolve()
+    expected_cache = (tmp_cache_root / "audio_cache/cached").resolve()
+    expected_tmp = (tmp_cache_root / "audio_cache/downloading").resolve()
 
     assert mod.audio_cache_dir == expected_cache
     assert mod.audio_tmp_dir == expected_tmp
@@ -87,7 +88,7 @@ def test_get_video_id_various_urls(tmp_cache_root):
 def test_get_cache_path_param(tmp_cache_root, url, rate, channels, expected_suffix):
     mod = import_module(tmp_cache_root)
     path = mod._get_cache_path(url, rate, channels)
-    expected_parent = (tmp_cache_root / "cached").resolve()
+    expected_parent = (tmp_cache_root / "audio_cache/cached").resolve()
     assert path.parent == expected_parent
     assert path.name == expected_suffix
 
@@ -104,7 +105,7 @@ def test_get_temp_paths(tmp_cache_root, url):
     mod = import_module(tmp_cache_root)
     opus_tmp, pcm_tmp = mod._get_temp_paths(url)
     vid = mod._get_video_id(url)
-    expected_tmp_dir = (tmp_cache_root / "downloading").resolve()
+    expected_tmp_dir = (tmp_cache_root / "audio_cache/downloading").resolve()
     assert opus_tmp.parent == expected_tmp_dir
     assert pcm_tmp.parent == expected_tmp_dir
     assert opus_tmp.name == f"{vid}.opus.part"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -52,6 +52,7 @@ async def test_load_extensions(monkeypatch):
 
     assert loaded == [
         "balaambot.bot_commands.bot_commands",
+        "balaambot.bot_commands.cat_commands",
         "balaambot.bot_commands.joke_commands",
         "balaambot.bot_commands.music_commands",
         "balaambot.bot_commands.sfx_commands",

--- a/uv.lock
+++ b/uv.lock
@@ -114,6 +114,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -195,6 +204,7 @@ dependencies = [
     { name = "discord-ext-voice-recv" },
     { name = "discord-py" },
     { name = "dotenv" },
+    { name = "pydantic" },
     { name = "pyjokes" },
     { name = "pynacl" },
     { name = "pytest-cov" },
@@ -217,6 +227,7 @@ requires-dist = [
     { name = "discord-ext-voice-recv", specifier = ">=0.4.2a145" },
     { name = "discord-py", specifier = ">=2.5.2" },
     { name = "dotenv", specifier = ">=0.9.9" },
+    { name = "pydantic", specifier = ">=2.11.5" },
     { name = "pyjokes", specifier = ">=0.8.3" },
     { name = "pynacl", specifier = ">=1.5.0" },
     { name = "pytest-cov", specifier = ">=6.1.1" },
@@ -817,6 +828,108 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.11.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/86/8ce9040065e8f924d642c58e4a344e33163a07f6b57f836d0d734e0ad3fb/pydantic-2.11.5.tar.gz", hash = "sha256:7f853db3d0ce78ce8bbb148c401c2cdd6431b3473c0cdff2755c7690952a7b7a", size = 787102, upload-time = "2025-05-22T21:18:08.761Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/69/831ed22b38ff9b4b64b66569f0e5b7b97cf3638346eb95a2147fdb49ad5f/pydantic-2.11.5-py3-none-any.whl", hash = "sha256:f9c26ba06f9747749ca1e5c94d6a85cb84254577553c8785576fd38fa64dc0f7", size = 444229, upload-time = "2025-05-22T21:18:06.329Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.33.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/88/5f2260bdfae97aabf98f1778d43f69574390ad787afb646292a638c923d4/pydantic_core-2.33.2.tar.gz", hash = "sha256:7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc", size = 435195, upload-time = "2025-04-23T18:33:52.104Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/92/b31726561b5dae176c2d2c2dc43a9c5bfba5d32f96f8b4c0a600dd492447/pydantic_core-2.33.2-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2b3d326aaef0c0399d9afffeb6367d5e26ddc24d351dbc9c636840ac355dc5d8", size = 2028817, upload-time = "2025-04-23T18:30:43.919Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/44/3f0b95fafdaca04a483c4e685fe437c6891001bf3ce8b2fded82b9ea3aa1/pydantic_core-2.33.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0e5b2671f05ba48b94cb90ce55d8bdcaaedb8ba00cc5359f6810fc918713983d", size = 1861357, upload-time = "2025-04-23T18:30:46.372Z" },
+    { url = "https://files.pythonhosted.org/packages/30/97/e8f13b55766234caae05372826e8e4b3b96e7b248be3157f53237682e43c/pydantic_core-2.33.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0069c9acc3f3981b9ff4cdfaf088e98d83440a4c7ea1bc07460af3d4dc22e72d", size = 1898011, upload-time = "2025-04-23T18:30:47.591Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/a3/99c48cf7bafc991cc3ee66fd544c0aae8dc907b752f1dad2d79b1b5a471f/pydantic_core-2.33.2-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d53b22f2032c42eaaf025f7c40c2e3b94568ae077a606f006d206a463bc69572", size = 1982730, upload-time = "2025-04-23T18:30:49.328Z" },
+    { url = "https://files.pythonhosted.org/packages/de/8e/a5b882ec4307010a840fb8b58bd9bf65d1840c92eae7534c7441709bf54b/pydantic_core-2.33.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0405262705a123b7ce9f0b92f123334d67b70fd1f20a9372b907ce1080c7ba02", size = 2136178, upload-time = "2025-04-23T18:30:50.907Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/bb/71e35fc3ed05af6834e890edb75968e2802fe98778971ab5cba20a162315/pydantic_core-2.33.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4b25d91e288e2c4e0662b8038a28c6a07eaac3e196cfc4ff69de4ea3db992a1b", size = 2736462, upload-time = "2025-04-23T18:30:52.083Z" },
+    { url = "https://files.pythonhosted.org/packages/31/0d/c8f7593e6bc7066289bbc366f2235701dcbebcd1ff0ef8e64f6f239fb47d/pydantic_core-2.33.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6bdfe4b3789761f3bcb4b1ddf33355a71079858958e3a552f16d5af19768fef2", size = 2005652, upload-time = "2025-04-23T18:30:53.389Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/7a/996d8bd75f3eda405e3dd219ff5ff0a283cd8e34add39d8ef9157e722867/pydantic_core-2.33.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:efec8db3266b76ef9607c2c4c419bdb06bf335ae433b80816089ea7585816f6a", size = 2113306, upload-time = "2025-04-23T18:30:54.661Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/84/daf2a6fb2db40ffda6578a7e8c5a6e9c8affb251a05c233ae37098118788/pydantic_core-2.33.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:031c57d67ca86902726e0fae2214ce6770bbe2f710dc33063187a68744a5ecac", size = 2073720, upload-time = "2025-04-23T18:30:56.11Z" },
+    { url = "https://files.pythonhosted.org/packages/77/fb/2258da019f4825128445ae79456a5499c032b55849dbd5bed78c95ccf163/pydantic_core-2.33.2-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:f8de619080e944347f5f20de29a975c2d815d9ddd8be9b9b7268e2e3ef68605a", size = 2244915, upload-time = "2025-04-23T18:30:57.501Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/7a/925ff73756031289468326e355b6fa8316960d0d65f8b5d6b3a3e7866de7/pydantic_core-2.33.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:73662edf539e72a9440129f231ed3757faab89630d291b784ca99237fb94db2b", size = 2241884, upload-time = "2025-04-23T18:30:58.867Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b0/249ee6d2646f1cdadcb813805fe76265745c4010cf20a8eba7b0e639d9b2/pydantic_core-2.33.2-cp310-cp310-win32.whl", hash = "sha256:0a39979dcbb70998b0e505fb1556a1d550a0781463ce84ebf915ba293ccb7e22", size = 1910496, upload-time = "2025-04-23T18:31:00.078Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ff/172ba8f12a42d4b552917aa65d1f2328990d3ccfc01d5b7c943ec084299f/pydantic_core-2.33.2-cp310-cp310-win_amd64.whl", hash = "sha256:b0379a2b24882fef529ec3b4987cb5d003b9cda32256024e6fe1586ac45fc640", size = 1955019, upload-time = "2025-04-23T18:31:01.335Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/8d/71db63483d518cbbf290261a1fc2839d17ff89fce7089e08cad07ccfce67/pydantic_core-2.33.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:4c5b0a576fb381edd6d27f0a85915c6daf2f8138dc5c267a57c08a62900758c7", size = 2028584, upload-time = "2025-04-23T18:31:03.106Z" },
+    { url = "https://files.pythonhosted.org/packages/24/2f/3cfa7244ae292dd850989f328722d2aef313f74ffc471184dc509e1e4e5a/pydantic_core-2.33.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e799c050df38a639db758c617ec771fd8fb7a5f8eaaa4b27b101f266b216a246", size = 1855071, upload-time = "2025-04-23T18:31:04.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/d3/4ae42d33f5e3f50dd467761304be2fa0a9417fbf09735bc2cce003480f2a/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dc46a01bf8d62f227d5ecee74178ffc448ff4e5197c756331f71efcc66dc980f", size = 1897823, upload-time = "2025-04-23T18:31:06.377Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f3/aa5976e8352b7695ff808599794b1fba2a9ae2ee954a3426855935799488/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a144d4f717285c6d9234a66778059f33a89096dfb9b39117663fd8413d582dcc", size = 1983792, upload-time = "2025-04-23T18:31:07.93Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/7a/cda9b5a23c552037717f2b2a5257e9b2bfe45e687386df9591eff7b46d28/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:73cf6373c21bc80b2e0dc88444f41ae60b2f070ed02095754eb5a01df12256de", size = 2136338, upload-time = "2025-04-23T18:31:09.283Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/b8f9ec8dd1417eb9da784e91e1667d58a2a4a7b7b34cf4af765ef663a7e5/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3dc625f4aa79713512d1976fe9f0bc99f706a9dee21dfd1810b4bbbf228d0e8a", size = 2730998, upload-time = "2025-04-23T18:31:11.7Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bc/cd720e078576bdb8255d5032c5d63ee5c0bf4b7173dd955185a1d658c456/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:881b21b5549499972441da4758d662aeea93f1923f953e9cbaff14b8b9565aef", size = 2003200, upload-time = "2025-04-23T18:31:13.536Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/22/3602b895ee2cd29d11a2b349372446ae9727c32e78a94b3d588a40fdf187/pydantic_core-2.33.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:bdc25f3681f7b78572699569514036afe3c243bc3059d3942624e936ec93450e", size = 2113890, upload-time = "2025-04-23T18:31:15.011Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/e6/e3c5908c03cf00d629eb38393a98fccc38ee0ce8ecce32f69fc7d7b558a7/pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:fe5b32187cbc0c862ee201ad66c30cf218e5ed468ec8dc1cf49dec66e160cc4d", size = 2073359, upload-time = "2025-04-23T18:31:16.393Z" },
+    { url = "https://files.pythonhosted.org/packages/12/e7/6a36a07c59ebefc8777d1ffdaf5ae71b06b21952582e4b07eba88a421c79/pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:bc7aee6f634a6f4a95676fcb5d6559a2c2a390330098dba5e5a5f28a2e4ada30", size = 2245883, upload-time = "2025-04-23T18:31:17.892Z" },
+    { url = "https://files.pythonhosted.org/packages/16/3f/59b3187aaa6cc0c1e6616e8045b284de2b6a87b027cce2ffcea073adf1d2/pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:235f45e5dbcccf6bd99f9f472858849f73d11120d76ea8707115415f8e5ebebf", size = 2241074, upload-time = "2025-04-23T18:31:19.205Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ed/55532bb88f674d5d8f67ab121a2a13c385df382de2a1677f30ad385f7438/pydantic_core-2.33.2-cp311-cp311-win32.whl", hash = "sha256:6368900c2d3ef09b69cb0b913f9f8263b03786e5b2a387706c5afb66800efd51", size = 1910538, upload-time = "2025-04-23T18:31:20.541Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/1b/25b7cccd4519c0b23c2dd636ad39d381abf113085ce4f7bec2b0dc755eb1/pydantic_core-2.33.2-cp311-cp311-win_amd64.whl", hash = "sha256:1e063337ef9e9820c77acc768546325ebe04ee38b08703244c1309cccc4f1bab", size = 1952909, upload-time = "2025-04-23T18:31:22.371Z" },
+    { url = "https://files.pythonhosted.org/packages/49/a9/d809358e49126438055884c4366a1f6227f0f84f635a9014e2deb9b9de54/pydantic_core-2.33.2-cp311-cp311-win_arm64.whl", hash = "sha256:6b99022f1d19bc32a4c2a0d544fc9a76e3be90f0b3f4af413f87d38749300e65", size = 1897786, upload-time = "2025-04-23T18:31:24.161Z" },
+    { url = "https://files.pythonhosted.org/packages/18/8a/2b41c97f554ec8c71f2a8a5f85cb56a8b0956addfe8b0efb5b3d77e8bdc3/pydantic_core-2.33.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a7ec89dc587667f22b6a0b6579c249fca9026ce7c333fc142ba42411fa243cdc", size = 2009000, upload-time = "2025-04-23T18:31:25.863Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/02/6224312aacb3c8ecbaa959897af57181fb6cf3a3d7917fd44d0f2917e6f2/pydantic_core-2.33.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3c6db6e52c6d70aa0d00d45cdb9b40f0433b96380071ea80b09277dba021ddf7", size = 1847996, upload-time = "2025-04-23T18:31:27.341Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/46/6dcdf084a523dbe0a0be59d054734b86a981726f221f4562aed313dbcb49/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e61206137cbc65e6d5256e1166f88331d3b6238e082d9f74613b9b765fb9025", size = 1880957, upload-time = "2025-04-23T18:31:28.956Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/6b/1ec2c03837ac00886ba8160ce041ce4e325b41d06a034adbef11339ae422/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eb8c529b2819c37140eb51b914153063d27ed88e3bdc31b71198a198e921e011", size = 1964199, upload-time = "2025-04-23T18:31:31.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/1d/6bf34d6adb9debd9136bd197ca72642203ce9aaaa85cfcbfcf20f9696e83/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c52b02ad8b4e2cf14ca7b3d918f3eb0ee91e63b3167c32591e57c4317e134f8f", size = 2120296, upload-time = "2025-04-23T18:31:32.514Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/94/2bd0aaf5a591e974b32a9f7123f16637776c304471a0ab33cf263cf5591a/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:96081f1605125ba0855dfda83f6f3df5ec90c61195421ba72223de35ccfb2f88", size = 2676109, upload-time = "2025-04-23T18:31:33.958Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/41/4b043778cf9c4285d59742281a769eac371b9e47e35f98ad321349cc5d61/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f57a69461af2a5fa6e6bbd7a5f60d3b7e6cebb687f55106933188e79ad155c1", size = 2002028, upload-time = "2025-04-23T18:31:39.095Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/d5/7bb781bf2748ce3d03af04d5c969fa1308880e1dca35a9bd94e1a96a922e/pydantic_core-2.33.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:572c7e6c8bb4774d2ac88929e3d1f12bc45714ae5ee6d9a788a9fb35e60bb04b", size = 2100044, upload-time = "2025-04-23T18:31:41.034Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/36/def5e53e1eb0ad896785702a5bbfd25eed546cdcf4087ad285021a90ed53/pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:db4b41f9bd95fbe5acd76d89920336ba96f03e149097365afe1cb092fceb89a1", size = 2058881, upload-time = "2025-04-23T18:31:42.757Z" },
+    { url = "https://files.pythonhosted.org/packages/01/6c/57f8d70b2ee57fc3dc8b9610315949837fa8c11d86927b9bb044f8705419/pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:fa854f5cf7e33842a892e5c73f45327760bc7bc516339fda888c75ae60edaeb6", size = 2227034, upload-time = "2025-04-23T18:31:44.304Z" },
+    { url = "https://files.pythonhosted.org/packages/27/b9/9c17f0396a82b3d5cbea4c24d742083422639e7bb1d5bf600e12cb176a13/pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:5f483cfb75ff703095c59e365360cb73e00185e01aaea067cd19acffd2ab20ea", size = 2234187, upload-time = "2025-04-23T18:31:45.891Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/6a/adf5734ffd52bf86d865093ad70b2ce543415e0e356f6cacabbc0d9ad910/pydantic_core-2.33.2-cp312-cp312-win32.whl", hash = "sha256:9cb1da0f5a471435a7bc7e439b8a728e8b61e59784b2af70d7c169f8dd8ae290", size = 1892628, upload-time = "2025-04-23T18:31:47.819Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e4/5479fecb3606c1368d496a825d8411e126133c41224c1e7238be58b87d7e/pydantic_core-2.33.2-cp312-cp312-win_amd64.whl", hash = "sha256:f941635f2a3d96b2973e867144fde513665c87f13fe0e193c158ac51bfaaa7b2", size = 1955866, upload-time = "2025-04-23T18:31:49.635Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/24/8b11e8b3e2be9dd82df4b11408a67c61bb4dc4f8e11b5b0fc888b38118b5/pydantic_core-2.33.2-cp312-cp312-win_arm64.whl", hash = "sha256:cca3868ddfaccfbc4bfb1d608e2ccaaebe0ae628e1416aeb9c4d88c001bb45ab", size = 1888894, upload-time = "2025-04-23T18:31:51.609Z" },
+    { url = "https://files.pythonhosted.org/packages/46/8c/99040727b41f56616573a28771b1bfa08a3d3fe74d3d513f01251f79f172/pydantic_core-2.33.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1082dd3e2d7109ad8b7da48e1d4710c8d06c253cbc4a27c1cff4fbcaa97a9e3f", size = 2015688, upload-time = "2025-04-23T18:31:53.175Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/cc/5999d1eb705a6cefc31f0b4a90e9f7fc400539b1a1030529700cc1b51838/pydantic_core-2.33.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f517ca031dfc037a9c07e748cefd8d96235088b83b4f4ba8939105d20fa1dcd6", size = 1844808, upload-time = "2025-04-23T18:31:54.79Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/5e/a0a7b8885c98889a18b6e376f344da1ef323d270b44edf8174d6bce4d622/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a9f2c9dd19656823cb8250b0724ee9c60a82f3cdf68a080979d13092a3b0fef", size = 1885580, upload-time = "2025-04-23T18:31:57.393Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/2a/953581f343c7d11a304581156618c3f592435523dd9d79865903272c256a/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2b0a451c263b01acebe51895bfb0e1cc842a5c666efe06cdf13846c7418caa9a", size = 1973859, upload-time = "2025-04-23T18:31:59.065Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/55/f1a813904771c03a3f97f676c62cca0c0a4138654107c1b61f19c644868b/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ea40a64d23faa25e62a70ad163571c0b342b8bf66d5fa612ac0dec4f069d916", size = 2120810, upload-time = "2025-04-23T18:32:00.78Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/c3/053389835a996e18853ba107a63caae0b9deb4a276c6b472931ea9ae6e48/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0fb2d542b4d66f9470e8065c5469ec676978d625a8b7a363f07d9a501a9cb36a", size = 2676498, upload-time = "2025-04-23T18:32:02.418Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/3c/f4abd740877a35abade05e437245b192f9d0ffb48bbbbd708df33d3cda37/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9fdac5d6ffa1b5a83bca06ffe7583f5576555e6c8b3a91fbd25ea7780f825f7d", size = 2000611, upload-time = "2025-04-23T18:32:04.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/a7/63ef2fed1837d1121a894d0ce88439fe3e3b3e48c7543b2a4479eb99c2bd/pydantic_core-2.33.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:04a1a413977ab517154eebb2d326da71638271477d6ad87a769102f7c2488c56", size = 2107924, upload-time = "2025-04-23T18:32:06.129Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8f/2551964ef045669801675f1cfc3b0d74147f4901c3ffa42be2ddb1f0efc4/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c8e7af2f4e0194c22b5b37205bfb293d166a7344a5b0d0eaccebc376546d77d5", size = 2063196, upload-time = "2025-04-23T18:32:08.178Z" },
+    { url = "https://files.pythonhosted.org/packages/26/bd/d9602777e77fc6dbb0c7db9ad356e9a985825547dce5ad1d30ee04903918/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:5c92edd15cd58b3c2d34873597a1e20f13094f59cf88068adb18947df5455b4e", size = 2236389, upload-time = "2025-04-23T18:32:10.242Z" },
+    { url = "https://files.pythonhosted.org/packages/42/db/0e950daa7e2230423ab342ae918a794964b053bec24ba8af013fc7c94846/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:65132b7b4a1c0beded5e057324b7e16e10910c106d43675d9bd87d4f38dde162", size = 2239223, upload-time = "2025-04-23T18:32:12.382Z" },
+    { url = "https://files.pythonhosted.org/packages/58/4d/4f937099c545a8a17eb52cb67fe0447fd9a373b348ccfa9a87f141eeb00f/pydantic_core-2.33.2-cp313-cp313-win32.whl", hash = "sha256:52fb90784e0a242bb96ec53f42196a17278855b0f31ac7c3cc6f5c1ec4811849", size = 1900473, upload-time = "2025-04-23T18:32:14.034Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/75/4a0a9bac998d78d889def5e4ef2b065acba8cae8c93696906c3a91f310ca/pydantic_core-2.33.2-cp313-cp313-win_amd64.whl", hash = "sha256:c083a3bdd5a93dfe480f1125926afcdbf2917ae714bdb80b36d34318b2bec5d9", size = 1955269, upload-time = "2025-04-23T18:32:15.783Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/86/1beda0576969592f1497b4ce8e7bc8cbdf614c352426271b1b10d5f0aa64/pydantic_core-2.33.2-cp313-cp313-win_arm64.whl", hash = "sha256:e80b087132752f6b3d714f041ccf74403799d3b23a72722ea2e6ba2e892555b9", size = 1893921, upload-time = "2025-04-23T18:32:18.473Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/7d/e09391c2eebeab681df2b74bfe6c43422fffede8dc74187b2b0bf6fd7571/pydantic_core-2.33.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:61c18fba8e5e9db3ab908620af374db0ac1baa69f0f32df4f61ae23f15e586ac", size = 1806162, upload-time = "2025-04-23T18:32:20.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/3d/847b6b1fed9f8ed3bb95a9ad04fbd0b212e832d4f0f50ff4d9ee5a9f15cf/pydantic_core-2.33.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95237e53bb015f67b63c91af7518a62a8660376a6a0db19b89acc77a4d6199f5", size = 1981560, upload-time = "2025-04-23T18:32:22.354Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/9a/e73262f6c6656262b5fdd723ad90f518f579b7bc8622e43a942eec53c938/pydantic_core-2.33.2-cp313-cp313t-win_amd64.whl", hash = "sha256:c2fc0a768ef76c15ab9238afa6da7f69895bb5d1ee83aeea2e3509af4472d0b9", size = 1935777, upload-time = "2025-04-23T18:32:25.088Z" },
+    { url = "https://files.pythonhosted.org/packages/30/68/373d55e58b7e83ce371691f6eaa7175e3a24b956c44628eb25d7da007917/pydantic_core-2.33.2-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:5c4aa4e82353f65e548c476b37e64189783aa5384903bfea4f41580f255fddfa", size = 2023982, upload-time = "2025-04-23T18:32:53.14Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/16/145f54ac08c96a63d8ed6442f9dec17b2773d19920b627b18d4f10a061ea/pydantic_core-2.33.2-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:d946c8bf0d5c24bf4fe333af284c59a19358aa3ec18cb3dc4370080da1e8ad29", size = 1858412, upload-time = "2025-04-23T18:32:55.52Z" },
+    { url = "https://files.pythonhosted.org/packages/41/b1/c6dc6c3e2de4516c0bb2c46f6a373b91b5660312342a0cf5826e38ad82fa/pydantic_core-2.33.2-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:87b31b6846e361ef83fedb187bb5b4372d0da3f7e28d85415efa92d6125d6e6d", size = 1892749, upload-time = "2025-04-23T18:32:57.546Z" },
+    { url = "https://files.pythonhosted.org/packages/12/73/8cd57e20afba760b21b742106f9dbdfa6697f1570b189c7457a1af4cd8a0/pydantic_core-2.33.2-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aa9d91b338f2df0508606f7009fde642391425189bba6d8c653afd80fd6bb64e", size = 2067527, upload-time = "2025-04-23T18:32:59.771Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/d5/0bb5d988cc019b3cba4a78f2d4b3854427fc47ee8ec8e9eaabf787da239c/pydantic_core-2.33.2-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2058a32994f1fde4ca0480ab9d1e75a0e8c87c22b53a3ae66554f9af78f2fe8c", size = 2108225, upload-time = "2025-04-23T18:33:04.51Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/c5/00c02d1571913d496aabf146106ad8239dc132485ee22efe08085084ff7c/pydantic_core-2.33.2-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:0e03262ab796d986f978f79c943fc5f620381be7287148b8010b4097f79a39ec", size = 2069490, upload-time = "2025-04-23T18:33:06.391Z" },
+    { url = "https://files.pythonhosted.org/packages/22/a8/dccc38768274d3ed3a59b5d06f59ccb845778687652daa71df0cab4040d7/pydantic_core-2.33.2-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:1a8695a8d00c73e50bff9dfda4d540b7dee29ff9b8053e38380426a85ef10052", size = 2237525, upload-time = "2025-04-23T18:33:08.44Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/e7/4f98c0b125dda7cf7ccd14ba936218397b44f50a56dd8c16a3091df116c3/pydantic_core-2.33.2-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:fa754d1850735a0b0e03bcffd9d4b4343eb417e47196e4485d9cca326073a42c", size = 2238446, upload-time = "2025-04-23T18:33:10.313Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/91/2ec36480fdb0b783cd9ef6795753c1dea13882f2e68e73bce76ae8c21e6a/pydantic_core-2.33.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:a11c8d26a50bfab49002947d3d237abe4d9e4b5bdc8846a63537b6488e197808", size = 2066678, upload-time = "2025-04-23T18:33:12.224Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/27/d4ae6487d73948d6f20dddcd94be4ea43e74349b56eba82e9bdee2d7494c/pydantic_core-2.33.2-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:dd14041875d09cc0f9308e37a6f8b65f5585cf2598a53aa0123df8b129d481f8", size = 2025200, upload-time = "2025-04-23T18:33:14.199Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b8/b3cb95375f05d33801024079b9392a5ab45267a63400bf1866e7ce0f0de4/pydantic_core-2.33.2-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d87c561733f66531dced0da6e864f44ebf89a8fba55f31407b00c2f7f9449593", size = 1859123, upload-time = "2025-04-23T18:33:16.555Z" },
+    { url = "https://files.pythonhosted.org/packages/05/bc/0d0b5adeda59a261cd30a1235a445bf55c7e46ae44aea28f7bd6ed46e091/pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2f82865531efd18d6e07a04a17331af02cb7a651583c418df8266f17a63c6612", size = 1892852, upload-time = "2025-04-23T18:33:18.513Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/11/d37bdebbda2e449cb3f519f6ce950927b56d62f0b84fd9cb9e372a26a3d5/pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bfb5112df54209d820d7bf9317c7a6c9025ea52e49f46b6a2060104bba37de7", size = 2067484, upload-time = "2025-04-23T18:33:20.475Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/55/1f95f0a05ce72ecb02a8a8a1c3be0579bbc29b1d5ab68f1378b7bebc5057/pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:64632ff9d614e5eecfb495796ad51b0ed98c453e447a76bcbeeb69615079fc7e", size = 2108896, upload-time = "2025-04-23T18:33:22.501Z" },
+    { url = "https://files.pythonhosted.org/packages/53/89/2b2de6c81fa131f423246a9109d7b2a375e83968ad0800d6e57d0574629b/pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:f889f7a40498cc077332c7ab6b4608d296d852182211787d4f3ee377aaae66e8", size = 2069475, upload-time = "2025-04-23T18:33:24.528Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/e9/1f7efbe20d0b2b10f6718944b5d8ece9152390904f29a78e68d4e7961159/pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:de4b83bb311557e439b9e186f733f6c645b9417c84e2eb8203f3f820a4b988bf", size = 2239013, upload-time = "2025-04-23T18:33:26.621Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/b2/5309c905a93811524a49b4e031e9851a6b00ff0fb668794472ea7746b448/pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:82f68293f055f51b51ea42fafc74b6aad03e70e191799430b90c13d643059ebb", size = 2238715, upload-time = "2025-04-23T18:33:28.656Z" },
+    { url = "https://files.pythonhosted.org/packages/32/56/8a7ca5d2cd2cda1d245d34b1c9a942920a718082ae8e54e5f3e5a58b7add/pydantic_core-2.33.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:329467cecfb529c925cf2bbd4d60d2c509bc2fb52a20c1045bf09bb70971a9c1", size = 2066757, upload-time = "2025-04-23T18:33:30.645Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1043,6 +1156,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d1/bc/51647cd02527e87d05cb083ccc402f93e441606ff1f01739a62c8ad09ba5/typing_extensions-4.14.0.tar.gz", hash = "sha256:8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4", size = 107423, upload-time = "2025-06-02T14:52:11.399Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/e0/552843e0d356fbb5256d21449fa957fa4eff3bbc135a74a691ee70c7c5da/typing_extensions-4.14.0-py3-none-any.whl", hash = "sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af", size = 43839, upload-time = "2025-06-02T14:52:10.026Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/b1/0c11f5058406b3af7609f121aaa6b609744687f1d158b3c3a5bf4cc94238/typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28", size = 75726, upload-time = "2025-05-21T18:55:23.885Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/69/cd203477f944c353c31bade965f880aa1061fd6bf05ded0726ca845b6ff7/typing_inspection-0.4.1-py3-none-any.whl", hash = "sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51", size = 14552, upload-time = "2025-05-21T18:55:22.152Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- New cat commands:
  - adopt cats
  - pet cats
  - view cats

- Added a check to see if the discord token was set with "..." since docker doesn't like those

- Optimized Dockerimage to use multi-stage building and removed unneeded files/deps when running - image should be much faster and smaller now especially after the first build

- Cats are saved under the persistent data directory. Audio cache has also been moved under the same directory so it can all share the same docker volume mount