### PR TITLE
Separate cat management by Discord guild and enhance functionality

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,9 +10,6 @@ These are smaller jobs, that shouldn't take too long to knock down individually.
 - [ ] sanitize sfx file names and find files with similar names
 - [ ] Bots should be segregated into their own dev channels on the dev server
 - [x] The `youtube_audio` script is getting too large, and has a lot of metadata stuff in it. Split it into `youtube_utils.py` and `youtube_audio.py`.
-- [x] Separate and optimize CI pipelines
-  - [x] Separate the build, lint and test pipelines
-  - [x] Speed up docker builds using caching
 - [x] Optimise the docker containers
   - [x] Update the dockerfiles to pull the sounds zip and unpack it only during the running phase, rather than packing it into the built image
   - [x] Deployment docker container doesnt use a builder phase
@@ -24,7 +21,6 @@ These are smaller jobs, that shouldn't take too long to knock down individually.
 - [x] Only build and push the docker image if the tests pass
 - [x] Report playback duration in the queue list command. Add a method to the audio mixer class to do that.
 - [x] If the play command doesnt get a valid youtube url, reject it and inform the user.
-
 # Mid-term TODO list
 
 These are things that will likely take over an hour
@@ -34,6 +30,9 @@ These are things that will likely take over an hour
 - [ ] Commands need to have guard clauses abstracted out into some discord utility functions
 - [ ] Add a way to scrub the currently playing track?
 - [ ] Send a message when a new track starts to play
+- [ ] Separate and optimize CI pipelines more
+  - [ ] Separate the CI pipeline and use the dedicated pipelines instead
+  - [ ] Speed up docker builds - make sure caching is working properly
 - [x] Allow users to search youtube for videos
 - [x] Youtube playlist support
 - [x] Test coverage is abysmal. Expand to cover all the stuff I've done since I last did a push on tests.

--- a/src/balaambot/bot_commands/cat_commands.py
+++ b/src/balaambot/bot_commands/cat_commands.py
@@ -26,15 +26,21 @@ class CatCommands(commands.Cog):
     @app_commands.describe(cat="The name of the cat to adopt")
     async def adopt_cat(self, interaction: discord.Interaction, cat: str) -> None:
         """Creates and saves a new pet cat."""
-        logger.info("Received adopt_cat command: %s (cat: %s)", interaction.user, cat)
+        logger.info(
+            "Received adopt_cat command: %s (cat: %s, guild_id: %d)",
+            interaction.user,
+            cat,
+            interaction.guild_id,
+        )
+        guild_id = 0 if interaction.guild_id is None else interaction.guild_id
 
-        if self.cat_handler.get_cat(cat):
+        if self.cat_handler.get_cat(cat, guild_id):
             await interaction.response.send_message(
                 f"We already have a cat named {cat}!",
             )
             return
 
-        self.cat_handler.add_cat(cat)
+        self.cat_handler.add_cat(cat, guild_id)
         await interaction.response.send_message(
             f"You adopted a new cat called {cat}! :cat:"
         )
@@ -44,17 +50,21 @@ class CatCommands(commands.Cog):
     async def pet_cat(self, interaction: discord.Interaction, cat: str) -> None:
         """Try to pet a cat with a chance to fail."""
         logger.info(
-            "Received pet_cat command from: %s (cat: %s)", interaction.user, cat
+            "Received pet_cat command from: %s (cat: %s, guild_id: %d)",
+            interaction.user,
+            cat,
+            interaction.guild_id,
         )
-        if self.cat_handler.get_num_cats() == 0:
+        guild_id = 0 if interaction.guild_id is None else interaction.guild_id
+        if self.cat_handler.get_num_cats(guild_id) == 0:
             await interaction.response.send_message(MSG_NO_CAT)
             return
 
-        target_cat = self.cat_handler.get_cat(cat)
+        target_cat = self.cat_handler.get_cat(cat, guild_id)
         if target_cat is None:
             await interaction.response.send_message(
                 f"We don't have any cats named {cat}. "
-                f"We have these:\n{self.cat_handler.get_cat_names()}.",
+                f"We have these:\n{self.cat_handler.get_cat_names(guild_id)}.",
             )
             return
 
@@ -71,13 +81,14 @@ class CatCommands(commands.Cog):
     async def list_cats(self, interaction: discord.Interaction) -> None:
         """List all of the server's cats."""
         logger.info("Received list_cats command from: %s", interaction.user)
-
-        if self.cat_handler.get_num_cats() == 0:
+        guild_id = 0 if interaction.guild_id is None else interaction.guild_id
+        if self.cat_handler.get_num_cats(guild_id) == 0:
             await interaction.response.send_message(MSG_NO_CAT)
             return
 
+        cat_list = self.cat_handler.get_cat_names(guild_id)
         await interaction.response.send_message(
-            f"We currently have these cats:\n{self.cat_handler.get_cat_names()}",
+            f"We currently have these cats:\n{cat_list}",
         )
 
 

--- a/src/balaambot/bot_commands/cat_commands.py
+++ b/src/balaambot/bot_commands/cat_commands.py
@@ -40,7 +40,7 @@ class CatCommands(commands.Cog):
             )
             return
 
-        self.cat_handler.add_cat(cat, guild_id)
+        self.cat_handler.add_cat(cat, guild_id, interaction.user.id)
         await interaction.response.send_message(
             f"You adopted a new cat called {cat}! :cat:"
         )

--- a/src/balaambot/bot_commands/cat_commands.py
+++ b/src/balaambot/bot_commands/cat_commands.py
@@ -36,13 +36,13 @@ class CatCommands(commands.Cog):
 
         if self.cat_handler.get_cat(cat, guild_id):
             await interaction.response.send_message(
-                f"We already have a cat named {cat}!",
+                f"We already have a cat named {cat}!", ephemeral=True
             )
             return
 
         self.cat_handler.add_cat(cat, guild_id, interaction.user.id)
         await interaction.response.send_message(
-            f"You adopted a new cat called {cat}! :cat:"
+            f"<@{interaction.user.id}> adopted a new cat called {cat}! :smile_cat:"
         )
 
     @app_commands.command(name="pet", description="Try to pet one of our cats!")
@@ -65,16 +65,20 @@ class CatCommands(commands.Cog):
             await interaction.response.send_message(
                 f"We don't have any cats named {cat}. "
                 f"We have these:\n{self.cat_handler.get_cat_names(guild_id)}.",
+                ephemeral=True,
             )
             return
 
         success = random.choices([True, False], [3, 1])  # noqa: S311
         if success[0]:
             msg = (
-                f"You successfully petted {target_cat}! They love it! :heart_eyes_cat:"
+                f"<@{interaction.user.id}> successfully petted {target_cat}! "
+                "They love it! :heart_eyes_cat:"
             )
         else:
-            msg = f"{target_cat} ran away before you could pet them!"
+            msg = (
+                f"{target_cat} ran away before <@{interaction.user.id}> could pet them!"
+            )
         await interaction.response.send_message(msg)
 
     @app_commands.command(name="list_cats", description="See all of our cats!")
@@ -83,12 +87,12 @@ class CatCommands(commands.Cog):
         logger.info("Received list_cats command from: %s", interaction.user)
         guild_id = 0 if interaction.guild_id is None else interaction.guild_id
         if self.cat_handler.get_num_cats(guild_id) == 0:
-            await interaction.response.send_message(MSG_NO_CAT)
+            await interaction.response.send_message(MSG_NO_CAT, ephemeral=True)
             return
 
         cat_list = self.cat_handler.get_cat_names(guild_id)
         await interaction.response.send_message(
-            f"We currently have these cats:\n{cat_list}",
+            f"We currently have these cats:\n{cat_list}"
         )
 
     @app_commands.command(

--- a/src/balaambot/bot_commands/cat_commands.py
+++ b/src/balaambot/bot_commands/cat_commands.py
@@ -91,6 +91,24 @@ class CatCommands(commands.Cog):
             f"We currently have these cats:\n{cat_list}",
         )
 
+    @app_commands.command(
+        name="remove_cat", description="Remove a cat you own from the server."
+    )
+    @app_commands.describe(cat="The name of the cat to remove")
+    async def remove_cat(self, interaction: discord.Interaction, cat: str) -> None:
+        """Remove a cat, only if the user is the owner."""
+        logger.info(
+            "Received remove_cat command: %s (cat: %s, guild_id: %d)",
+            interaction.user,
+            cat,
+            interaction.guild_id,
+        )
+        guild_id = 0 if interaction.guild_id is None else interaction.guild_id
+        success, message = self.cat_handler.remove_cat(
+            cat, guild_id, interaction.user.id
+        )
+        await interaction.response.send_message(message)
+
 
 async def setup(bot: commands.Bot) -> None:
     """Load the CatCommands cog."""

--- a/src/balaambot/cats/cat_handler.py
+++ b/src/balaambot/cats/cat_handler.py
@@ -18,6 +18,7 @@ class Cat(pydantic.BaseModel):
     """Data representing a cat."""
 
     name: str
+    owner: int  # Discord user ID of the owner
 
 
 class CatData(pydantic.BaseModel):
@@ -64,24 +65,26 @@ class CatHandler:
         return cat.name if cat else None
 
     def get_cat_names(self, guild_id: int) -> str:
-        """Get a formatted list of cat names."""
+        """Get a formatted list of cat names and owners."""
         return "\n".join(
-            f"- {cat.name}" for cat in self.db.guild_cats.get(guild_id, {}).values()
+            f"- {cat.name} (Owner: <@{cat.owner}>)"
+            for cat in self.db.guild_cats.get(guild_id, {}).values()
         )
 
-    def add_cat(self, cat_name: str, guild_id: int) -> None:
+    def add_cat(self, cat_name: str, guild_id: int, owner_id: int) -> None:
         """Creates a new cat.
 
         Args:
             cat_name (str): The name of the cat to create
             guild_id (int): The Discord guild to create them in
+            owner_id (int): The Discord user ID of the owner
 
         """
         cat_id = self._get_cat_id(cat_name)
         # Make a new cat and save it
         if guild_id not in self.db.guild_cats:
             self.db.guild_cats[guild_id] = {}
-        self.db.guild_cats[guild_id][cat_id] = Cat(name=cat_name)
+        self.db.guild_cats[guild_id][cat_id] = Cat(name=cat_name, owner=owner_id)
         self._save_cat_db(self.db)
 
     def _get_cat_id(self, cat_name: str) -> str:

--- a/src/balaambot/cats/cat_handler.py
+++ b/src/balaambot/cats/cat_handler.py
@@ -87,6 +87,42 @@ class CatHandler:
         self.db.guild_cats[guild_id][cat_id] = Cat(name=cat_name, owner=owner_id)
         self._save_cat_db(self.db)
 
+    def remove_cat(
+        self, cat_name: str, guild_id: int, user_id: int
+    ) -> tuple[bool, str]:
+        """Remove a cat if the user is the owner.
+
+        Args:
+            cat_name (str): The name of the cat to remove
+            guild_id (int): The Discord guild to remove from
+            user_id (int): The Discord user ID of the user requesting removal
+
+        Returns:
+            tuple[bool, str]: (success, message)
+
+        """
+        cat_id = self._get_cat_id(cat_name)
+        cats = self.db.guild_cats.get(guild_id, {})
+        cat_obj = cats.get(cat_id)
+        if not cat_obj:
+            return False, f"No cat named {cat_name} exists."
+        if cat_obj.owner != user_id:
+            return (
+                False,
+                f"You are not the owner of {cat_obj.name}. "
+                "Only the owner can remove this cat. :pouting_cat:",
+            )
+        del cats[cat_id]
+        self.db.guild_cats[guild_id] = cats
+        self._save_cat_db(self.db)
+        return (
+            True,
+            (
+                f"{cat_obj.name} has been removed from the server. "
+                "Goodbye! :crying_cat_face:"
+            ),
+        )
+
     def _get_cat_id(self, cat_name: str) -> str:
         return cat_name.strip().lower()
 

--- a/tests/cats/test_cat_handler.py
+++ b/tests/cats/test_cat_handler.py
@@ -27,13 +27,15 @@ def test_init_no_file(patch_save_file, patch_logger):
     assert handler.get_num_cats(GUILD_ID) == 0
 
 def test_init_with_valid_file(patch_save_file, patch_logger):
-    cats_data = {"guild_cats": {str(GUILD_ID): {"mittens": {"name": "Mittens"}}}}
+    owner_id = 123456
+    cats_data = {"guild_cats": {str(GUILD_ID): {"mittens": {"name": "Mittens", "owner": owner_id}}}}
     patch_save_file.write_text(json.dumps(cats_data))
     handler = CatHandler()
     assert "mittens" in handler.db.guild_cats.get(GUILD_ID, {})
     cat_obj = handler.db.guild_cats[GUILD_ID]["mittens"]
     assert isinstance(cat_obj, cat_handler.Cat)
     assert cat_obj.name == "Mittens"
+    assert cat_obj.owner == owner_id
 
 def test_init_with_invalid_json(patch_save_file, patch_logger, monkeypatch):
     logged = {}
@@ -48,10 +50,12 @@ def test_init_with_invalid_json(patch_save_file, patch_logger, monkeypatch):
 
 def test_add_cat_creates_and_persists(patch_save_file, patch_logger):
     handler = CatHandler()
-    handler.add_cat("Whiskers", GUILD_ID)
+    owner_id = 555
+    handler.add_cat("Whiskers", GUILD_ID, owner_id)
     cat_obj = handler.db.guild_cats[GUILD_ID].get("whiskers")
     assert isinstance(cat_obj, cat_handler.Cat)
     assert cat_obj.name == "Whiskers"
+    assert cat_obj.owner == owner_id
     assert handler.get_cat("whiskers", GUILD_ID) == "Whiskers"
     # File should exist and contain the cat
     with patch_save_file.open() as f:
@@ -60,35 +64,42 @@ def test_add_cat_creates_and_persists(patch_save_file, patch_logger):
     assert str(GUILD_ID) in data["guild_cats"]
     assert "whiskers" in data["guild_cats"][str(GUILD_ID)]
     assert data["guild_cats"][str(GUILD_ID)]["whiskers"]["name"] == "Whiskers"
+    assert data["guild_cats"][str(GUILD_ID)]["whiskers"]["owner"] == owner_id
 
 def test_add_cat_normalizes_id(patch_save_file, patch_logger):
     handler = CatHandler()
-    handler.add_cat("  Fluffy  ", GUILD_ID)
+    owner_id = 123
+    handler.add_cat("  Fluffy  ", GUILD_ID, owner_id)
     # All these should return the original name as stored
     assert handler.get_cat("fluffy", GUILD_ID) == "  Fluffy  "
     assert handler.get_cat("  FLUFFY", GUILD_ID) == "  Fluffy  "
     assert handler.get_cat("FlUfFy", GUILD_ID) == "  Fluffy  "
     assert handler.get_cat("other", GUILD_ID) is None
+    # Owner is correct
+    cat_obj = handler.db.guild_cats[GUILD_ID]["fluffy"]
+    assert cat_obj.owner == owner_id
 
 def test_get_cat_names(patch_save_file, patch_logger):
     handler = CatHandler()
-    handler.add_cat("A", GUILD_ID)
-    handler.add_cat("B", GUILD_ID)
+    owner1 = 1
+    owner2 = 2
+    handler.add_cat("A", GUILD_ID, owner1)
+    handler.add_cat("B", GUILD_ID, owner2)
     names = handler.get_cat_names(GUILD_ID)
-    assert "- A" in names
-    assert "- B" in names
+    assert f"- A (Owner: <@{owner1}>)" in names
+    assert f"- B (Owner: <@{owner2}>)" in names
     assert names.count("- ") == 2
 
 def test_get_num_cats(patch_save_file, patch_logger):
     handler = CatHandler()
     assert handler.get_num_cats(GUILD_ID) == 0
-    handler.add_cat("X", GUILD_ID)
-    handler.add_cat("Y", GUILD_ID)
+    handler.add_cat("X", GUILD_ID, 1)
+    handler.add_cat("Y", GUILD_ID, 2)
     assert handler.get_num_cats(GUILD_ID) == 2
 
 def test_save_creates_file_if_missing(patch_save_file, patch_logger):
     handler = CatHandler()
-    handler.add_cat("Zed", GUILD_ID)
+    handler.add_cat("Zed", GUILD_ID, 42)
     assert patch_save_file.exists()
     with patch_save_file.open() as f:
         data = json.load(f)
@@ -96,6 +107,7 @@ def test_save_creates_file_if_missing(patch_save_file, patch_logger):
     assert str(GUILD_ID) in data["guild_cats"]
     assert "zed" in data["guild_cats"][str(GUILD_ID)]
     assert data["guild_cats"][str(GUILD_ID)]["zed"]["name"] == "Zed"
+    assert data["guild_cats"][str(GUILD_ID)]["zed"]["owner"] == 42
 
 def test_get_cat_id_normalization(patch_save_file, patch_logger):
     handler = CatHandler()
@@ -106,8 +118,8 @@ def test_cats_are_isolated_by_guild(patch_save_file, patch_logger):
     handler = CatHandler()
     guild1 = 111
     guild2 = 222
-    handler.add_cat("Mittens", guild1)
-    handler.add_cat("Fluffy", guild2)
+    handler.add_cat("Mittens", guild1, 1)
+    handler.add_cat("Fluffy", guild2, 2)
     # Each guild only sees its own cats
     assert handler.get_cat("Mittens", guild1) == "Mittens"
     assert handler.get_cat("Fluffy", guild1) is None
@@ -126,8 +138,8 @@ def test_guilds_are_persisted_separately(patch_save_file, patch_logger):
     handler = CatHandler()
     guild1 = 333
     guild2 = 444
-    handler.add_cat("Tiger", guild1)
-    handler.add_cat("Shadow", guild2)
+    handler.add_cat("Tiger", guild1, 10)
+    handler.add_cat("Shadow", guild2, 20)
     # Save and reload
     handler2 = CatHandler()
     assert handler2.get_cat("Tiger", guild1) == "Tiger"

--- a/tests/cats/test_cat_handler.py
+++ b/tests/cats/test_cat_handler.py
@@ -152,3 +152,33 @@ def test_get_cat_returns_none_if_guild_missing(patch_save_file, patch_logger):
     # Use a guild_id that does not exist
     cat = handler.get_cat("anycat", 99999)
     assert cat is None
+
+def test_remove_cat_success(patch_save_file, patch_logger):
+    handler = CatHandler()
+    owner_id = 123
+    handler.add_cat("Whiskers", GUILD_ID, owner_id)
+    # Remove as owner
+    success, msg = handler.remove_cat("Whiskers", GUILD_ID, owner_id)
+    assert success is True
+    assert "removed" in msg
+    # Cat is gone
+    assert handler.get_cat("Whiskers", GUILD_ID) is None
+
+def test_remove_cat_not_owner(patch_save_file, patch_logger):
+    handler = CatHandler()
+    owner_id = 123
+    other_id = 456
+    handler.add_cat("Whiskers", GUILD_ID, owner_id)
+    # Try to remove as non-owner
+    success, msg = handler.remove_cat("Whiskers", GUILD_ID, other_id)
+    assert success is False
+    assert "not the owner" in msg
+    # Cat still exists
+    assert handler.get_cat("Whiskers", GUILD_ID) == "Whiskers"
+
+def test_remove_cat_not_exist(patch_save_file, patch_logger):
+    handler = CatHandler()
+    # Try to remove a cat that doesn't exist
+    success, msg = handler.remove_cat("Ghost", GUILD_ID, 123)
+    assert success is False
+    assert "No cat named Ghost exists" in msg


### PR DESCRIPTION
Implement functionality to manage cats per Discord guild, including storing the owner of each cat, adding a command to remove cats, and ensuring some commands are ephemeral.