### PR TITLE
Fix metadata cache miss error message

### DIFF
--- a/src/balaambot/youtube/audio.py
+++ b/src/balaambot/youtube/audio.py
@@ -93,7 +93,7 @@ def fetch_cached_youtube_track_metadata(url: str) -> VideoMetadata:
         logger.info("Loaded metadata from cache: '%s'", meta_path)
         return data
 
-    msg = "No metadata cached for url '%s'", url
+    msg = f"No metadata cached for url '{url}'"
     raise FileNotFoundError(msg)
 
 


### PR DESCRIPTION
## Summary
- correct `fetch_cached_youtube_track_metadata` error message to be a string

## Testing
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fdf2f9b708320b10a59b679527439