### PR TITLE
Fix typos and improve sec_to_string tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Permissions:
  - `Use Voice Activity`
  - `View Channels`
 
-Priviledged Intents:
+Privileged Intents:
  - `Message Content Intent`
 
 # Future Work

--- a/src/balaambot/bot_commands/music_commands.py
+++ b/src/balaambot/bot_commands/music_commands.py
@@ -95,7 +95,7 @@ class MusicCommands(commands.Cog):
 
         # Fall back to searching youtube and asking the user to select a search result
         if query:
-            logger.info("Recieved a string. Searching youtube for videos. '%s'", query)
+            logger.info("Received a string. Searching youtube for videos. '%s'", query)
             self.bot.loop.create_task(self.do_search_youtube(interaction, query))
             return
 

--- a/src/balaambot/bot_commands/sfx_commands.py
+++ b/src/balaambot/bot_commands/sfx_commands.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 # - sanitize sfx file names and find files with similar names
 # - add fuzzy search
 # - add basic file browser with discord msg buttons
-# - intergrate with soundboard api?
+# - integrate with soundboard API?
 
 
 class SFXCommands(commands.Cog):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,16 @@
-def test_sec_to_string():
-    from src.balaambot.utils import sec_to_string
-    assert sec_to_string(5) == "00:05"
-    assert sec_to_string(65) == "01:05"
-    assert sec_to_string(3665) == "01:01:05"
+import pytest
+from balaambot.utils import sec_to_string
+
+@pytest.mark.parametrize(
+    "seconds,expected",
+    [
+        (0, "00:00"),
+        (5, "00:05"),
+        (65, "01:05"),
+        (3600, "01:00:00"),
+        (3665, "01:01:05"),
+    ],
+)
+def test_sec_to_string(seconds, expected):
+    assert sec_to_string(seconds) == expected
+


### PR DESCRIPTION
## Summary
- correct `Privileged Intents` header in README
- fix spelling in a TODO comment for SFX commands
- fix logger message typo in music commands
- parameterize `sec_to_string` unit tests and fix import

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684fdf2f5c648320aa3c73304cf86e9d