### PR TITLE
Refactor guard clauses into discord utils

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -21,7 +21,7 @@ These are things that will likely take over an hour
   - [ ] tentatively solved. Needs thorough testing though
 - [ ] Should we stream opus data rather than PCM?
 - [ ] Youtube age restricts some content, so I need to implement auth
-- [ ] Commands need to have guard clauses abstracted out into some discord utility functions
+ - [x] Commands need to have guard clauses abstracted out into some discord utility functions
 - [ ] Add a way to scrub the currently playing track?
 - [ ] Separate and optimize CI pipelines more
   - [x] Separate the CI pipeline and use the dedicated pipelines instead

--- a/src/balaambot/bot_commands/music_commands.py
+++ b/src/balaambot/bot_commands/music_commands.py
@@ -213,26 +213,13 @@ class MusicCommands(commands.Cog):
     async def list_queue(self, interaction: discord.Interaction) -> None:
         """Show the current YouTube queue for this server."""
         await interaction.response.defer(ephemeral=True, thinking=True)
-        if interaction.guild is None:
-            await interaction.followup.send(
-                "This command only works in a server.",
-                ephemeral=True,
-            )
+        channel_member = await discord_utils.require_voice_channel(interaction)
+        if channel_member is None:
             return
-        member = interaction.guild.get_member(interaction.user.id)
-        if (
-            not member
-            or not member.voice
-            or not isinstance(member.voice.channel, discord.VoiceChannel)
-        ):
-            await interaction.followup.send(
-                "You need to be in a standard voice channel to view the queue.",
-                ephemeral=True,
-            )
-            return
+        channel, _member = channel_member
         vc = await discord_utils.ensure_connected(
             interaction.guild,
-            member.voice.channel,
+            channel,
         )
         upcoming = await yt_jobs.list_queue(vc)
 
@@ -277,25 +264,13 @@ class MusicCommands(commands.Cog):
     async def skip(self, interaction: discord.Interaction) -> None:
         """Stop current track and play next in queue."""
         await interaction.response.defer(ephemeral=True, thinking=True)
-        if interaction.guild is None:
-            await interaction.followup.send(
-                "This command only works in a server.", ephemeral=True
-            )
+        channel_member = await discord_utils.require_voice_channel(interaction)
+        if channel_member is None:
             return
-        member = interaction.guild.get_member(interaction.user.id)
-        if (
-            not member
-            or not member.voice
-            or not isinstance(member.voice.channel, discord.VoiceChannel)
-        ):
-            await interaction.followup.send(
-                "You need to be in a standard voice channel to skip audio.",
-                ephemeral=True,
-            )
-            return
+        channel, _member = channel_member
         vc = await discord_utils.ensure_connected(
             interaction.guild,
-            member.voice.channel,
+            channel,
         )
         await yt_jobs.skip(vc)
         logger.info("Skipped track for guild_id=%s", interaction.guild.id)
@@ -325,25 +300,13 @@ class MusicCommands(commands.Cog):
     )
     async def stop_music(self, interaction: discord.Interaction) -> None:
         """Stop the current YouTube track and clear all queued tracks."""
-        if interaction.guild is None:
-            await interaction.response.send_message(
-                "This command only works in a server.", ephemeral=True
-            )
+        channel_member = await discord_utils.require_voice_channel(interaction)
+        if channel_member is None:
             return
-        member = interaction.guild.get_member(interaction.user.id)
-        if (
-            not member
-            or not member.voice
-            or not isinstance(member.voice.channel, discord.VoiceChannel)
-        ):
-            await interaction.response.send_message(
-                "You need to be in a standard voice channel to stop music.",
-                ephemeral=True,
-            )
-            return
+        channel, _member = channel_member
         vc = await discord_utils.ensure_connected(
             interaction.guild,
-            member.voice.channel,
+            channel,
         )
         await yt_jobs.stop(vc)
         await interaction.response.send_message(
@@ -353,25 +316,11 @@ class MusicCommands(commands.Cog):
     @app_commands.command(name="clear_queue", description="Clear the YouTube queue")
     async def clear_queue(self, interaction: discord.Interaction) -> None:
         """Remove all queued YouTube tracks."""
-        if interaction.guild is None:
-            await interaction.response.send_message(
-                "This command only works in a server.", ephemeral=True
-            )
+        channel_member = await discord_utils.require_voice_channel(interaction)
+        if channel_member is None:
             return
-        member = interaction.guild.get_member(interaction.user.id)
-        if (
-            not member
-            or not member.voice
-            or not isinstance(member.voice.channel, discord.VoiceChannel)
-        ):
-            await interaction.response.send_message(
-                "You need to be in a standard voice channel to clear the queue.",
-                ephemeral=True,
-            )
-            return
-        vc = await discord_utils.ensure_connected(
-            interaction.guild, member.voice.channel
-        )
+        channel, _member = channel_member
+        vc = await discord_utils.ensure_connected(interaction.guild, channel)
         logger.info("Clearing YouTube queue for guild_id=%s", interaction.guild.id)
 
         # Clear the queue


### PR DESCRIPTION
## Summary
- centralize guild and voice-channel checks in `discord_utils`
- update bot commands to use the new helpers
- extend unit tests for new util functions
- mark TODO item as done

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6850930f279c8320a3a408faaa6888db