### PR TITLE
Async ffmpeg invocation

### DIFF
--- a/src/balaambot/bot_commands/sfx_commands.py
+++ b/src/balaambot/bot_commands/sfx_commands.py
@@ -139,7 +139,7 @@ class SFXCommands(commands.Cog):
         vc = await discord_utils.ensure_connected(guild, channel)
         mixer = await discord_utils.get_mixer_from_interaction(interaction)
 
-        mixer.play_file(sound)
+        await mixer.play_file(sound)
         if not vc.is_playing():
             vc.play(mixer)
         await interaction.followup.send(
@@ -173,7 +173,7 @@ class SFXCommands(commands.Cog):
         mixer = await discord_utils.get_mixer_from_interaction(interaction)
 
         try:
-            mixer.play_file(sound)
+            await mixer.play_file(sound)
             if not vc.is_playing():
                 vc.play(mixer)
 

--- a/src/balaambot/sfx/audio_sfx_jobs.py
+++ b/src/balaambot/sfx/audio_sfx_jobs.py
@@ -57,7 +57,7 @@ async def _play_sfx_loop(vc: discord_utils.DISCORD_VOICE_CLIENT, job_id: str) ->
 
             try:
                 mixer = discord_utils.get_mixer_from_voice_client(vc)
-                mixer.play_file(sound, after_play=_after_play)
+                await mixer.play_file(sound, after_play=_after_play)
             except Exception:
                 logger.exception("Error playing %s", sound)
                 await remove_job(job_id)

--- a/tests/sfx/test_audio_sfx_jobs.py
+++ b/tests/sfx/test_audio_sfx_jobs.py
@@ -158,7 +158,7 @@ async def test_play_sfx_loop_success_one_iteration(monkeypatch):
         def __init__(self):
             self.played = []
 
-        def play_file(self, sound, after_play=None):
+        async def play_file(self, sound, after_play=None):
             # simulate immediate playback
             if after_play:
                 after_play()
@@ -183,9 +183,9 @@ async def test_play_sfx_loop_success_one_iteration(monkeypatch):
     # To exit after one iteration, remove job within after_play
     original_after = dummy_mixer.play_file
 
-    def wrapped_play_file(sound, after_play=None):
+    async def wrapped_play_file(sound, after_play=None):
         # call original then schedule removal
-        original_after(sound, after_play)
+        await original_after(sound, after_play)
         # remove job to break loop
         asyncio.get_event_loop().create_task(sfx.remove_job(job_id))
 


### PR DESCRIPTION
## Summary
- make `MultiAudioSource.play_file` async and spawn ffmpeg with `create_subprocess_exec`
- await `play_file` in sound effect commands and loop
- update tests for the new async API

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68594299d1c08320bf35837987194755