### PR TITLE
Fix discord.py version to use master branch directly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ authors = [
 requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
-    "discord.py>=2.5.2",
     "anyio>=4.9.0",
     "dotenv>=0.9.9",
     "pynacl>=1.5.0",
@@ -21,6 +20,7 @@ dependencies = [
     "redis>=6.2.0",
     "pytest-asyncio>=1.0.0",
     "rapidfuzz>=3.13.0",
+    "discord-py",
 ]
 
 # Dev tools
@@ -42,3 +42,6 @@ balaambot = "balaambot:main.start"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.uv.sources]
+discord-py = { git = "https://github.com/Rapptz/discord.py", rev = "master" }

--- a/uv.lock
+++ b/uv.lock
@@ -241,7 +241,7 @@ dev = [
 requires-dist = [
     { name = "anyio", specifier = ">=4.9.0" },
     { name = "discord-ext-voice-recv", specifier = ">=0.4.2a145" },
-    { name = "discord-py", specifier = ">=2.5.2" },
+    { name = "discord-py", git = "https://github.com/Rapptz/discord.py?rev=master" },
     { name = "dotenv", specifier = ">=0.9.9" },
     { name = "pydantic", specifier = ">=2.11.5" },
     { name = "pyjokes", specifier = ">=0.8.3" },
@@ -432,15 +432,11 @@ wheels = [
 
 [[package]]
 name = "discord-py"
-version = "2.5.2"
-source = { registry = "https://pypi.org/simple" }
+version = "2.6.0a5227+g7724764f"
+source = { git = "https://github.com/Rapptz/discord.py?rev=master#7724764ffebebf1584847b49ff6823f6c0402d01" }
 dependencies = [
     { name = "aiohttp" },
     { name = "audioop-lts", marker = "python_full_version >= '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7f/dd/5817c7af5e614e45cdf38cbf6c3f4597590c442822a648121a34dee7fa0f/discord_py-2.5.2.tar.gz", hash = "sha256:01cd362023bfea1a4a1d43f5280b5ef00cad2c7eba80098909f98bf28e578524", size = 1054879, upload-time = "2025-03-05T01:15:29.798Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/a8/dc908a0fe4cd7e3950c9fa6906f7bf2e5d92d36b432f84897185e1b77138/discord_py-2.5.2-py3-none-any.whl", hash = "sha256:81f23a17c50509ffebe0668441cb80c139e74da5115305f70e27ce821361295a", size = 1155105, upload-time = "2025-03-05T01:15:27.323Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
There is a bug going around in the discord.py package, which prevents the bot from joining voice channels. There's a fix, but it's not in any released versions yet, so for now I'll use the main branch directly since it works for now. When discord.py 2.6 is released, I'll need to remember to bump the version over to that.

https://github.com/Rapptz/discord.py/issues/10207