### PR TITLE
Swap which order videos and playlists are checked for

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,10 @@ updates:
       interval: daily
     commit-message:
       prefix: "chore(github-actions)"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore(docker)"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,8 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Auto-approve
-        uses: hmarr/auto-approve-action@v3
+        uses: hmarr/auto-approve-action@v4
       - name: Enable auto-merge
-        uses: peter-evans/enable-pull-request-automerge@v2
+        uses: peter-evans/enable-pull-request-automerge@v3
         with:
+          token: ${{ secrets.AUTO_MERGE_GITHUB_TOKEN }}
           merge-method: squash

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -68,5 +68,6 @@
         "editor.formatOnSave": true,
         "editor.insertSpaces": true,
         "editor.tabSize": 2
-    }
+    },
+    "python-envs.pythonProjects": []
 }

--- a/src/balaambot/bot_commands/music_commands.py
+++ b/src/balaambot/bot_commands/music_commands.py
@@ -189,7 +189,10 @@ class MusicCommands(commands.Cog):
             return
 
     @app_commands.command(
-        name="play", description="Enqueue and play a YouTube video audio"
+        name="play",
+        description=(
+            "Enqueue and play a YouTube video audio (placed on the back of the queue)"
+        ),
     )
     @app_commands.describe(query="YouTube URL, playlist URL, or search term")
     async def play(self, interaction: discord.Interaction, query: str) -> None:
@@ -205,6 +208,37 @@ class MusicCommands(commands.Cog):
         """
         await interaction.response.defer(thinking=True, ephemeral=True)
         await self._enqueue(interaction, query, "play", queue_to_top=False)
+
+    @app_commands.command(name="play_list", description="queue up a whole playlist")
+    async def play_playlist(
+        self, interaction: discord.Interaction, query: str, *, queue_to_top: bool = True
+    ) -> None:
+        """Enqueue the playlist contained in a youtube URL.
+
+        Parameters
+        ----------
+        interaction : discord.Interaction
+            The interaction from Discord.
+        query : str
+            The YouTube URL, playlist URL, or search term to search and play.
+        queue_to_top : bool
+            If true, then the tracks will be added to the head of the queue.
+
+        """
+        task = self.do_play_playlist(interaction, query, queue_to_top=queue_to_top)
+        task = self.bot.loop.create_task(task)
+        try:
+            await task
+        except Exception as e:
+            logger.exception(
+                "Error while processing play_list command for query '%s'",
+                query,
+            )
+            await interaction.followup.send(
+                f"An error occurred while processing your play_list request: {e}",
+                ephemeral=True,
+            )
+            return
 
     @app_commands.command(
         name="play_next", description="Queue a track to the top of the queue"
@@ -295,34 +329,35 @@ class MusicCommands(commands.Cog):
     async def do_play(
         self, interaction: discord.Interaction, url: str, *, queue_to_top: bool = False
     ) -> None:
-        """Play a YouTube video by fetching and streaming the audio from the URL."""
+        """Play a YouTube video by fetching and streaming the audio from the URL.
+
+        The interaction passed in is assumed to have been deferred earlier.
+        """
         # Check if the user is in a voice channel
         vc_mixer = await discord_utils.get_voice_channel_mixer(interaction)
         if vc_mixer is None:
             return
         vc, mixer = vc_mixer
 
-        # Add to queue. Playback (in mixer) will await cache when it's time
-        await yt_jobs.add_to_queue(
+        track_id = yt_utils.get_video_id(url)
+        url = f"https://youtube.com/watch?v={track_id}"
+
+        track_meta = await yt_audio.get_youtube_track_metadata(url)
+        # Playback (in mixer) will await cache when it's time
+        pos = await yt_jobs.add_to_queue(
             vc, [url], text_channel=interaction.channel_id, queue_to_top=queue_to_top
         )
 
-        track_meta = await yt_audio.get_youtube_track_metadata(url)
         if track_meta is None:
+            # Remove the url from the queue
+            await yt_jobs.prune_queue(vc, index=pos)
             await interaction.followup.send(
                 f"Failed to fetch track metadata. Please check the URL. [{url}]",
                 ephemeral=True,
             )
             return
 
-        queue = await yt_jobs.list_queue(vc)
-        try:
-            pos = queue.index(url) + 1
-        except ValueError:
-            pos = -1
-
         runtime = track_meta["runtime_str"]
-
         msg = (
             f"🎵    Queued **[{track_meta['title']}]({track_meta['url']})"
             f" ({runtime})** at position {pos}."

--- a/src/balaambot/bot_commands/music_commands.py
+++ b/src/balaambot/bot_commands/music_commands.py
@@ -163,12 +163,12 @@ class MusicCommands(commands.Cog):
             )
             return
 
-        if yt_utils.is_valid_youtube_playlist(query):
-            logger.info("%s playlist URL: %s", command_name, query)
-            task = self.do_play_playlist(interaction, query, queue_to_top=queue_to_top)
-        elif yt_utils.is_valid_youtube_url(query):
+        if yt_utils.is_valid_youtube_url(query):
             logger.info("%s video URL: %s", command_name, query)
             task = self.do_play(interaction, query, queue_to_top=queue_to_top)
+        elif yt_utils.is_valid_youtube_playlist(query):
+            logger.info("%s playlist URL: %s", command_name, query)
+            task = self.do_play_playlist(interaction, query, queue_to_top=queue_to_top)
         else:
             logger.info("%s search query: %s", command_name, query)
             task = self.do_search_youtube(interaction, query, queue_to_top=queue_to_top)

--- a/src/balaambot/bot_commands/music_commands.py
+++ b/src/balaambot/bot_commands/music_commands.py
@@ -225,10 +225,13 @@ class MusicCommands(commands.Cog):
             If true, then the tracks will be added to the head of the queue.
 
         """
+        await interaction.response.defer(thinking=True, ephemeral=True)
         task = self.do_play_playlist(interaction, query, queue_to_top=queue_to_top)
-        task = self.bot.loop.create_task(task)
+
         try:
-            await task
+            logger.info("Adding playlist task to bot")
+            await self.bot.loop.create_task(task)
+            logger.info("DONE")
         except Exception as e:
             logger.exception(
                 "Error while processing play_list command for query '%s'",

--- a/src/balaambot/youtube/jobs.py
+++ b/src/balaambot/youtube/jobs.py
@@ -39,6 +39,10 @@ async def add_to_queue(
     """
     queue = youtube_queue.setdefault(vc.guild.id, [])
 
+    new_queue = False
+    if queue == []:
+        new_queue = True
+
     current_track = queue[0] if queue else None
 
     # remove current track if exists
@@ -70,7 +74,7 @@ async def add_to_queue(
         vc.loop.run_in_executor(utils.FUTURES_EXECUTOR, get_metadata, logger, url)
 
     # If this is the only item, start playback
-    if len(queue) == 1:
+    if new_queue:
         logger.info("Queue created for guild_id=%s, starting playback", vc.guild.id)
 
         # Start playback immediately
@@ -81,6 +85,8 @@ async def add_to_queue(
             # If we fail to start playback, we should clear the queue
             youtube_queue.pop(vc.guild.id, None)
             raise
+    else:
+        logger.info("Queue already existed. Not starting playback")
 
     return queue.index(urls[0])
 

--- a/src/balaambot/youtube/jobs.py
+++ b/src/balaambot/youtube/jobs.py
@@ -30,10 +30,12 @@ async def add_to_queue(
     text_channel: int | None = None,
     *,
     queue_to_top: bool = False,
-) -> None:
+) -> int:
     """Add YouTube URLs to the playback queue for the given voice client.
 
     If nothing is playing, start playback immediately.
+
+    Returns the queue position of the first URL added.
     """
     queue = youtube_queue.setdefault(vc.guild.id, [])
 
@@ -79,6 +81,8 @@ async def add_to_queue(
             # If we fail to start playback, we should clear the queue
             youtube_queue.pop(vc.guild.id, None)
             raise
+
+    return queue.index(urls[0])
 
 
 async def _maybe_preload_next_tracks(

--- a/src/balaambot/youtube/metadata.py
+++ b/src/balaambot/youtube/metadata.py
@@ -76,15 +76,18 @@ async def get_playlist_video_urls(playlist_url: str) -> list[str]:
         "quiet": True,
         "skip_download": True,
         "extract_flat": "in_playlist",
+        "playlistend": 40,
     }
     ydl_opts = add_auth_cookie(ydl_opts)
 
-    def _extract_playlist(opts: dict[str, Any], url: str) -> dict[str, Any] | None:
+    async def _extract_playlist(
+        opts: dict[str, Any], url: str
+    ) -> dict[str, Any] | None:
         with YoutubeDL(opts) as ydl:
             return ydl.extract_info(url, download=False)  # type: ignore[no-typing]
 
     try:
-        info = await asyncio.to_thread(_extract_playlist, ydl_opts, playlist_url)
+        info = await _extract_playlist(ydl_opts, playlist_url)
     except DownloadError as e:
         logger.warning(
             "yt-dlp failed to extract playlist info for %s: %s", playlist_url, e

--- a/src/balaambot/youtube/utils.py
+++ b/src/balaambot/youtube/utils.py
@@ -205,6 +205,16 @@ def is_valid_youtube_playlist(url: str) -> bool:
     return _VALID_YT_PLAYLIST_URL.match(url) is not None
 
 
+def get_playlist_id(url: str) -> str:
+    """Extract the playlist ID from the youtube URL."""
+    match = _VALID_YT_PLAYLIST_URL.match(url)
+    if match is not None:
+        return match.group("playlist_id")
+
+    msg = f"Failed to get playlist ID from url '{url}'"
+    raise ValueError(msg)
+
+
 def get_audio_pcm(
     url: str, sample_rate: int = DEFAULT_SAMPLE_RATE, channels: int = DEFAULT_CHANNELS
 ) -> bytearray | None:

--- a/tests/youtube/test_audio.py
+++ b/tests/youtube/test_audio.py
@@ -558,11 +558,17 @@ async def test_playlist_valid(monkeypatch):
     ]
     info = {"entries": entries}
 
-    # Stub thread call to return our info
-    async def fake_to_thread(func, opts, url):
-        return info
+    class DummyYDL:
+        def __enter__(self):
+            return self
 
-    monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
+        def __exit__(self, *args):
+            return False
+
+        def extract_info(self, u, download):
+            return info
+
+    monkeypatch.setattr(metadata, "YoutubeDL", lambda opts: DummyYDL())
     # Capture calls to extract_metadata
     called = []
     async def fake_extract(entry):


### PR DESCRIPTION
For links like this:
```
https://www.youtube.com/watch?v=-5lobdvz4k4&list=RD-5lobdvz4k4
```

We DONT want to add like, 2000 videos to the queue. Instead, prioritise playing the video only. If the user wants the playlist, they should use the /play_list command